### PR TITLE
Suppress some reorder warnings generally and type mismatch warnings in tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Set compiler flags
-set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG -g3 -gdwarf-3 -Wall")
+set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG -g3 -gdwarf-3 -Wall -Wno-reorder")
 set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG -O3 -fvisibility=hidden")
 set(CMAKE_CXX_FLAGS_COVERAGE "-DDEBUG -g3 -gdwarf-3 --coverage")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,9 @@ set(AZURE_STORAGE_TEST_SOURCES
   integration/append_blob_integration_test.cpp
   integration/page_blob_integration_test.cpp
   integration/performance_test.cpp
-)
+  )
+
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-sign-compare")
 
 add_executable(azure-storage-test ${AZURE_STORAGE_TEST_SOURCES})
 if(WIN32)


### PR DESCRIPTION
Addressing some new warnings during compilation because of moving to explicit compiler flags in #1 .