### PR TITLE
Fix memory leak with uploads/downloads using std::async

### DIFF
--- a/adls/include/adls_client.h
+++ b/adls/include/adls_client.h
@@ -320,8 +320,8 @@ namespace azure { namespace storage_adls {
         }
 
     private:
-        std::shared_ptr<azure::storage_lite::blob_client> m_blob_client;
         std::shared_ptr<storage_account> m_account;
+        std::shared_ptr<azure::storage_lite::blob_client> m_blob_client;
         std::shared_ptr<executor_context> m_context;
 
         const bool m_exception_enabled;

--- a/adls/test/directory_test.cpp
+++ b/adls/test/directory_test.cpp
@@ -3,6 +3,8 @@
 #include "adls_client.h"
 #include "adls_test_base.h"
 
+#include <unistd.h>
+
 TEST_CASE("Create Directory", "[adls][directory]")
 {
     {
@@ -171,6 +173,8 @@ TEST_CASE("Move Directory", "[adls][directory]")
     // Move a directory into another directory
     client.move_directory(fs1_name, src_dir, fs2_name, dest_dir);
     REQUIRE(errno == 0);
+
+    sleep(10);
 
     REQUIRE_FALSE(client.file_exists(fs1_name, src_dir + "/" + file1));
     REQUIRE_FALSE(client.file_exists(fs1_name, src_dir + "/" + file2));

--- a/src/blob/blob_client.cpp
+++ b/src/blob/blob_client.cpp
@@ -111,9 +111,10 @@ std::future<storage_outcome<void>> blob_client::download_blob_to_buffer(const st
     const uint64_t grain_size = 64 * 1024;
     uint64_t block_size = size / parallelism;
     block_size = (block_size + grain_size - 1) / grain_size * grain_size;
-    block_size = std::min(block_size, constants::default_block_size);
 
     int num_blocks = int((size + block_size - 1) / block_size);
+
+    parallelism = std::min(parallelism, num_blocks);
 
     struct concurrent_task_info
     {
@@ -245,6 +246,8 @@ std::future<storage_outcome<void>> blob_client::upload_block_blob_from_buffer(co
     block_size = std::max(block_size, constants::default_block_size);
 
     int num_blocks = int((bufferlen + block_size - 1) / block_size);
+
+    parallelism = std::min(parallelism, num_blocks);
 
     std::vector<put_block_list_request_base::block_item> block_list;
     block_list.reserve(num_blocks);

--- a/src/blob/blob_client.cpp
+++ b/src/blob/blob_client.cpp
@@ -246,8 +246,6 @@ std::future<storage_outcome<void>> blob_client::upload_block_blob_from_buffer(co
 
     int num_blocks = int((bufferlen + block_size - 1) / block_size);
 
-    parallelism = std::min(parallelism, num_blocks);
-
     std::vector<put_block_list_request_base::block_item> block_list;
     block_list.reserve(num_blocks);
     std::string uuid = get_uuid();

--- a/src/blob/blob_client.cpp
+++ b/src/blob/blob_client.cpp
@@ -108,14 +108,14 @@ std::future<storage_outcome<void>> blob_client::download_blob_to_stream(const st
 
 std::future<storage_outcome<void>> blob_client::download_blob_to_buffer(const std::string &container, const std::string &blob, unsigned long long offset, unsigned long long size, char* buffer, int parallelism)
 {
-    parallelism = std::min(parallelism, int(concurrency()));
-
     const uint64_t grain_size = 64 * 1024;
     uint64_t block_size = size / parallelism;
     block_size = (block_size + grain_size - 1) / grain_size * grain_size;
     block_size = std::min(block_size, constants::default_block_size);
 
     int num_blocks = int((size + block_size - 1) / block_size);
+
+    parallelism = std::min(parallelism, num_blocks);
 
     struct concurrent_task_info
     {


### PR DESCRIPTION
Data structures that are created via `std::shared_ptr` and passed to `std::async` are not getting released causing memory leaks. This is because there is no way to link `context->task_promise.get_future()` that is being returned by the parallel upload/download to `context->task_futures` that is the result of the multiple spawned async threads. There is a `[std::experimental::future<T>::then](https://en.cppreference.com/w/cpp/experimental/future/then)`, but it looks like it may have been removed in C++2x. For now, since the upload/download does a get() on the http/curl call for each thread, just specifically invoking a `context->task_futures[i].get()` to free up the allocated resources.

Also as part of this PR

- Fixed the number of threads to be a minimum of num_blocks and parallelism as there is no point invoking std::async with nothing to process.
- Cleaned up some compiler warnings.